### PR TITLE
Add exception parameter to catch block

### DIFF
--- a/src/rules/package-size.js
+++ b/src/rules/package-size.js
@@ -37,7 +37,7 @@ class PackageSize extends Adviser.Rule {
         const dependencyPath = path.join(...directoryFragments, name, 'package.json');
         const dependencyMeta = require(dependencyPath);
         return { name: name, version: dependencyMeta.version };
-      } catch {
+      } catch (_e) {
         return { name: name, version: 'latest' };
       }
     });


### PR DESCRIPTION
## Summary:
Update `package-size` syntax to support older versions of node, currently testing in node `v8.11.3`, an error is thrown when implementing the rule in the `.adviserrc`.

- Add an `exception_var` to the catch block on line 40

## Test Plan:
Run command `adviser - --debug` and check if that no error is thrown. Ensure that adviser completes running.

*Before:*
![Screen Shot 2020-03-31 at 9 24 39 AM](https://user-images.githubusercontent.com/36141243/78032016-59c71600-7332-11ea-9f96-0f0ff3910683.png)

*After:*
![Screen Shot 2020-03-31 at 9 37 56 AM](https://user-images.githubusercontent.com/36141243/78032750-7dd72700-7333-11ea-86c3-e09af8164526.png)
