### PR TITLE
fix: update usage after dependency upgrade

### DIFF
--- a/src/rules/package-size.js
+++ b/src/rules/package-size.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const getBuiltPackageStats = require('package-build-stats');
+const { getPackageStats } = require('package-build-stats');
 const Adviser = require('adviser');
 
 const docs = require('../utils/docs');
@@ -100,7 +100,7 @@ class PackageSize extends Adviser.Rule {
     const packagejson = require(path.join(this.context.filesystem.dirname, 'package.json'));
     const names = this._getDependencyNames(packagejson, this.parsedOptions.whitelist);
     const versions = this._extractDependencyVersions([this.context.filesystem.dirname, 'node_modules'], names);
-    const stats = await this._generateDependencyStats(getBuiltPackageStats, versions);
+    const stats = await this._generateDependencyStats(getPackageStats, versions);
     const skips = this._identifySkips(stats);
     const largePackages = this._identifyLargePackages(stats, this.parsedOptions.threshold);
 


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [x] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description
Package size rule is broke by previously merged [PR](https://github.com/Jam3/adviser-plugin-dependencies/pull/11) upgraded a package that required a code update to the package rule.

## Solution Description
Update the module call in the rule

**Before:**
<img width="386" alt="Screen Shot 2020-10-29 at 2 47 29 PM" src="https://user-images.githubusercontent.com/36141243/97618666-b0deb780-19f5-11eb-915b-6d603e30987f.png">

**After:**
<img width="411" alt="Screen Shot 2020-10-29 at 2 45 02 PM" src="https://user-images.githubusercontent.com/36141243/97618616-a3293200-19f5-11eb-88e6-e7bba4849869.png">
